### PR TITLE
Allow external urls for nav links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,9 +39,9 @@ minima:
   nav_pages:
     - about.md
     - url: https://www.are.na/institute-for-human-sciences/index
-    title: Programs
+      title: Programs
     - url: https://humansciences.micro.blog
-    title: Microblog
+      title: Microblog
     - people.md
 
 # Exclude from processing.

--- a/_includes/nav-items.html
+++ b/_includes/nav-items.html
@@ -1,0 +1,8 @@
+<div class="nav-items">
+  {%- for path in include.paths -%}
+  {%- assign hyperpage = site.pages | where: "path", path | first -%}
+  {%- if hyperpage.title %}
+  <a class="nav-item" href="{{ hyperpage.url | relative_url }}">{{ hyperpage.title | escape }}</a>
+  {%- endif -%}
+  {%- endfor %}
+</div>

--- a/_includes/nav-items.html
+++ b/_includes/nav-items.html
@@ -1,8 +1,12 @@
 <div class="nav-items">
   {%- for path in include.paths -%}
+  {% if path.url and path.title %}
+  <a class="nav-item" href="{{ path.url }}">{{ path.title }}</a>
+  {% else %}
   {%- assign hyperpage = site.pages | where: "path", path | first -%}
   {%- if hyperpage.title %}
   <a class="nav-item" href="{{ hyperpage.url | relative_url }}">{{ hyperpage.title | escape }}</a>
   {%- endif -%}
   {%- endfor %}
+  {% endif %}
 </div>

--- a/_includes/nav-items.html
+++ b/_includes/nav-items.html
@@ -7,6 +7,6 @@
   {%- if hyperpage.title %}
   <a class="nav-item" href="{{ hyperpage.url | relative_url }}">{{ hyperpage.title | escape }}</a>
   {%- endif -%}
-  {%- endfor %}
   {% endif %}
+  {%- endfor %}
 </div>


### PR DESCRIPTION
want to be able to link to both other pages within the jekyll site, but then also external links if we give them as url/title pairs.

So first just went over to the base theme and copy/pasted the thing we want to override:
- commit: https://github.com/human-sciences/human-sciences.github.io/commit/3790f007ffc41040b1044bee25129ac71d8d5853
- original version in `minima` repo: https://github.com/jekyll/minima/blob/bf9ef989246b63536e9db61082f663f1a6d4d9ce/_includes/nav-items.html

and then we modify it to support the changes in our `nav_pages` structure (i messed up and put that in the same commit as the yaml indentation thing but it didn't matter enough to amend the commit): https://github.com/human-sciences/human-sciences.github.io/commit/eddc99c15060799b481feca7525a4493e1beb2d4