### PR TITLE
Randomize order of people on the people page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,9 +39,9 @@ minima:
   nav_pages:
     - about.md
     - url: https://www.are.na/institute-for-human-sciences/index
-    title: Programs
+      title: Programs
     - url: https://humansciences.micro.blog
-    title: Microblog
+      title: Microblog
     - people.md
 
 # Exclude from processing.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,37 @@
+<link id="fa-stylesheet" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@7.0.0/css/all.min.css">
+
+<footer class="site-footer h-card">
+  <data class="u-url" value="{{ '/' | relative_url }}"></data>
+
+  <div class="wrapper">
+
+    <div class="footer-col-wrapper">
+      <div class="footer-col">
+      {%- if site.author %}
+        <ul class="contact-list">
+          {% if site.author.name -%}
+            <li class="p-name">{{ site.author.name | escape }}</li>
+          {% endif -%}
+          {% if site.author.email -%}
+            <li><a class="u-email" href="mailto:{{ site.author.email }}">{{ site.author.email }}</a></li>
+          {%- endif %}
+        </ul>
+      {%- endif %}
+      </div>
+      <div class="footer-col">
+        <p>{{ site.description | escape }}</p>
+      </div>
+    </div>
+
+    <div class="social-links">
+      {%- include social.html -%}
+    </div>
+
+  </div>
+{% if page.extra_js %}
+{% for script in page.extra_js %}
+<script src="{{ script | relative_url }}"></script>
+{% endfor %}
+{% endif %}
+
+</footer>

--- a/assets/js/randomize.js
+++ b/assets/js/randomize.js
@@ -1,11 +1,9 @@
+// Randomize the order of the people on the people page!
 function randomize_order(){
-	console.log('randomizing')
 	let parent = document.querySelector('.post-content');
 	let people = document.querySelectorAll('.post-content > p');
-	console.log(people);
 	let shuffled = Array.from(people).sort(() => Math.random() - 0.5);
 	shuffled.forEach(person => parent.appendChild(person));
-	console.log(shuffled);
 }
 
 document.addEventListener("load", randomize_order());

--- a/assets/js/randomize.js
+++ b/assets/js/randomize.js
@@ -1,0 +1,11 @@
+function randomize_order(){
+	console.log('randomizing')
+	let parent = document.querySelector('.post-content');
+	let people = document.querySelectorAll('.post-content > p');
+	console.log(people);
+	let shuffled = Array.from(people).sort(() => Math.random() - 0.5);
+	shuffled.forEach(person => parent.appendChild(person));
+	console.log(shuffled);
+}
+
+document.addEventListener("load", randomize_order());

--- a/people.md
+++ b/people.md
@@ -2,6 +2,8 @@
 layout: page
 title: People
 permalink: /people/
+extra_js:
+  - /assets/js/randomize.js
 ---
 
 [Anton Bruder](https://www.zotero.org/antonbruder), Utrecht


### PR DESCRIPTION
another example of overriding templates and adding custom javascript.

So we can randomize the order in which items are presented on the page every time it's loaded without needing to re-render the whole site.

to do what, we want to add some custom javascript to only one page (we don't want to randomize the order of other pages).

The *real* way one would want to do this would be to make a template for each person/institute/etc. to be rendered, declare the list of people/institutes/etc. as data, and then render them with predictable CSS classes that could be used to select them from the JS.

However, if the content of the page will always be structured such that each line is a separate `p` tag, this works just as well.

Note that again most of the `footer.html` template is just copy/pasted from the base template: https://github.com/human-sciences/human-sciences.github.io/commit/01a23f17ab7b7fe1b24439ce5387d4a4ad8628e7 and we just added the `extra_js` lines at the bottom of that.

so then we 
- add a list of extra js files we want to include on the page (people.md header)
- embed those extra js files in the footer template (footer.html)
- in the js we just embedded, we randomize the order of the people `p` tags!

