### PR TITLE
Css not overlapping stuff

### DIFF
--- a/_sass/minima/custom-styles.scss
+++ b/_sass/minima/custom-styles.scss
@@ -5,6 +5,7 @@
 .mainmatter {
 	display: flex;
 	flex-direction: row;
+	flex-grow: 1;
 }
 
 

--- a/_sass/minima/custom-styles.scss
+++ b/_sass/minima/custom-styles.scss
@@ -43,10 +43,13 @@
 	right: 0;
 	top: 0;
 	background-color: var(--minima-background-color);
-	height: 13em;
-	width: 13em;
+	height: 15em;
+	width: 15em;
 	padding: 1em;
 	border: 5px solid var(--minima-heading-border-color);
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .site-title {
@@ -75,7 +78,5 @@
 }
 
 footer {
-	position: absolute;
-	bottom: 0;
 	width: 100%;
 }


### PR DESCRIPTION
currently the header text sort of leaks out of the box and the footer invades the middle of the page
<img width="1280" height="1340" alt="Screenshot 2026-02-09 at 1 42 43 AM" src="https://github.com/user-attachments/assets/57219bf7-f1da-49e5-a5ec-09ab0e461f6a" />

<img width="1269" height="469" alt="Screenshot 2026-02-09 at 1 46 03 AM" src="https://github.com/user-attachments/assets/9bbe78b0-5b1c-4151-91ed-4b272c53debc" />

so this makes that not happen by adding more flexbox

<img width="1280" height="1342" alt="Screenshot 2026-02-09 at 1 44 56 AM" src="https://github.com/user-attachments/assets/559977c4-eedb-4ded-9acd-d8f63c5df659" />
<img width="1274" height="644" alt="Screenshot 2026-02-09 at 1 45 07 AM" src="https://github.com/user-attachments/assets/a0e09237-335a-46e2-b531-412ba1dfe259" />

